### PR TITLE
Match upstream naming convention for resourceclaim

### DIFF
--- a/translate-engagement-data/files/ocp-init/templates/resourceclaim.j2
+++ b/translate-engagement-data/files/ocp-init/templates/resourceclaim.j2
@@ -4,7 +4,7 @@
 apiVersion: poolboy.gpte.redhat.com/v1
 kind: ResourceClaim
 metadata:
-  name: anarchy-subject-{{ .Values.project_id }}
+  name: labs.ocp4.na-{{ .Values.project_id }}
 spec:
   resources:
   - template:


### PR DESCRIPTION
This aligns better with upstream naming convention. It is also confusing have a resourceclaim named `anarchy-subject` (which is a different CR).