### PR TITLE
Add autosync to template and inventory

### DIFF
--- a/gitlab-to-argo/files/application_template.j2
+++ b/gitlab-to-argo/files/application_template.j2
@@ -14,3 +14,9 @@ spec:
       {{ item.ssh_url_to_repo }}
     targetRevision: "{{ target_revision }}"
   project: default
+{% if syncPolicy is defined and syncPolicy | bool %}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{% endif %}

--- a/gitlab-to-argo/inventory/group_vars/all.yml
+++ b/gitlab-to-argo/inventory/group_vars/all.yml
@@ -3,3 +3,4 @@ chart_path: "."
 target_revision: HEAD
 created_by: gitlab-argo-integration
 resource_prefix: gitlab-app
+syncPolicy: false 


### PR DESCRIPTION
This allows us to control whether we want autosync to be enabled within an environment based on whether an inventory var `autoSync` is set to true.

Going to leave this as `WIP` until we've got the appropriate environments configured appropriately so that it can target specific releases/branches.

cc/ @jacobsee 