### PR TITLE
Pull in governor_name as var instead of generating it

### DIFF
--- a/inventory-generation/identity-management/main.yml
+++ b/inventory-generation/identity-management/main.yml
@@ -11,6 +11,12 @@
     when:
       - directory is undefined or (directory | trim) == ""
 
+  - name: "Fail If Governor Name Is Not Provided"
+    fail:
+      msg: "governor_name var needs to be provided in order to indicate babylon workflow"
+    when:
+      - governor_name is undefined or (governor_name | trim) == ""
+
   - name: Read Engagement Data
     include_vars:
       file: "{{ directory }}/engagement.json"
@@ -64,11 +70,6 @@
     copy:
       content: "[identity-hosts]\nlocalhost"
       dest: "{{ directory }}/iac/inventories/identity-management/inventory/hosts"
-
-  - name: "Assemble governor name"
-    set_fact:
-      governor_name: "{{ 'labs.ocp4.' + (engagement_region | default('na') | lower) }}"
-
 
   - name: "Create ResourceClaim"
     copy:


### PR DESCRIPTION
This pulls in the governor_name as a variable that is passed as part of our dispatcher config instead of trying to be too smart and assembling it based off of other info.