### PR TITLE
Remove to_nice_yaml from claim_content, the template takes care of it

### DIFF
--- a/translate-engagement-data/site.yml
+++ b/translate-engagement-data/site.yml
@@ -31,9 +31,6 @@
         ocp_ldap_sa_user: "{{ ocp_ldap_sa_username }}"
         ocp_ldap_sa_password: "{{ ocp_ldap_sa_password }}"
         ocp_subdomain: "{{ ocp_sub_domain }}"
-  - name: Format Claim Content
-    set_fact:
-      claim_content: "{{ claim_content | to_nice_yaml }}"
   - name: Create Resource Claim
     copy:
       content: "{{ lookup('template', inventory_dir + '/../files/templates/resourceclaim.yaml.j2') }}"


### PR DESCRIPTION
The `to_nice_yaml` has moved into the `templates/resourceclaim.yaml.j2` and is no longer needed (causes problems) in the playbook.