### PR TITLE
Adding a default Tower Admin username

### DIFF
--- a/inventory-generation/tower_jobs_launch/README.md
+++ b/inventory-generation/tower_jobs_launch/README.md
@@ -12,6 +12,6 @@ Some additional variables are required to be passed in from a private config fil
 | organization | Tower Org | y | NA |
 | ansible_tower_url | Tower URL | y | NA |
 | ansible_tower_admin_password | Tower Admin Password | y | NA |
-| ansible_tower_admin_username | Tower User Name | y | NA |
+| ansible_tower_admin_username | Tower Admin Username | n | admin |
 | scm_credential_name | Name of the existing Source Credential in Tower | y | NA |
 | ssh_key_data_path | The path to the SCM private key used to access GitLab | y | NA |

--- a/inventory-generation/tower_jobs_launch/README.md
+++ b/inventory-generation/tower_jobs_launch/README.md
@@ -12,6 +12,6 @@ Some additional variables are required to be passed in from a private config fil
 | organization | Tower Org | y | NA |
 | ansible_tower_url | Tower URL | y | NA |
 | ansible_tower_admin_password | Tower Admin Password | y | NA |
-| ansible_tower_username | Tower User Name | y | NA |
+| ansible_tower_admin_username | Tower User Name | y | NA |
 | scm_credential_name | Name of the existing Source Credential in Tower | y | NA |
 | ssh_key_data_path | The path to the SCM key used by resource-dispatcher to access GitLab | y | NA |

--- a/inventory-generation/tower_jobs_launch/README.md
+++ b/inventory-generation/tower_jobs_launch/README.md
@@ -14,4 +14,4 @@ Some additional variables are required to be passed in from a private config fil
 | ansible_tower_admin_password | Tower Admin Password | y | NA |
 | ansible_tower_admin_username | Tower User Name | y | NA |
 | scm_credential_name | Name of the existing Source Credential in Tower | y | NA |
-| ssh_key_data_path | The path to the SCM key used by resource-dispatcher to access GitLab | y | NA |
+| ssh_key_data_path | The path to the SCM private key used to access GitLab | y | NA |

--- a/inventory-generation/tower_jobs_schedules/README.md
+++ b/inventory-generation/tower_jobs_schedules/README.md
@@ -17,5 +17,6 @@ Some additional variables are required to be passed in from a private config fil
 | organization | Tower Org | y | NA |
 | scm_credential_name | Credential name for checking out repos | y | NA |
 | ansible_tower_url | Tower URL | y | NA |
+| ansible_tower_admin_username | Tower Admin Username | no | admin |
 | ansible_tower_admin_password | Tower Admin Password | y | NA |
 | mail_host_source_project | Project name for mail-host credentials | y | NA |

--- a/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
+++ b/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
@@ -8,6 +8,7 @@ delete_missing_items: false
 
 ansible_tower:
   url: "{{ ansible_tower_url }}"
+  admin_username: "{{ ansible_tower_admin_username | default('admin') }}"
   admin_password: "{{ ansible_tower_admin_password }}"
   projects:
     - name: "{{ customer_engagement }}-project"


### PR DESCRIPTION
Minor change to also include tower username - with a default value of `admin`. 