### PR TITLE
Reverting back to ansible-2.9 'kind'

### DIFF
--- a/inventory-generation/tower_jobs_launch/main.yaml
+++ b/inventory-generation/tower_jobs_launch/main.yaml
@@ -29,7 +29,7 @@
           tower_credential:
             name: "{{ scm_credential_name }}"
             organization: "{{ organization }}"
-            credential_type: Source Control
+            kind: scm
             state: present
             inputs:
               ssh_key_data: "{{ lookup('file', ssh_key_data_path) }}"


### PR DESCRIPTION
This key needs to be `kind` as per https://docs.ansible.com/ansible/2.9/modules/tower_credential_module.html#parameter-kind

In Ansible 2.10 `credential_type: Source Control` will be the preferred with `kind` being deprecated.