### PR TITLE
Remove ansible-2.10 inputs dict in favor of 2.9 ssh_key_data

### DIFF
--- a/inventory-generation/tower_jobs_launch/main.yaml
+++ b/inventory-generation/tower_jobs_launch/main.yaml
@@ -30,9 +30,8 @@
             name: "{{ scm_credential_name }}"
             organization: "{{ organization }}"
             kind: scm
+            ssh_key_data: "{{ lookup('file', ssh_key_data_path) }}"
             state: present
-            inputs:
-              ssh_key_data: "{{ lookup('file', ssh_key_data_path) }}"
 
         - name: "Create the {{ customer_engagement }}-project"
           tower_project:    


### PR DESCRIPTION
Looks like I missed one more ansible 2.10 to 2.9 where inputs has not yet been moved into a dict