### PR TITLE
Fix credential with ssh_key_data under inputs

### DIFF
--- a/inventory-generation/tower_jobs_launch/main.yaml
+++ b/inventory-generation/tower_jobs_launch/main.yaml
@@ -26,7 +26,8 @@
             - name: '{{ scm_credential_name }}'
               organization: '{{ organization }}'
               credential_type: Source Control
-              ssh_key_data: "{{ lookup('file', ssh_key_data_path) }}"
+              inputs:
+                ssh_key_data: "{{ lookup('file', ssh_key_data_path) }}"
           projects:
             - name: '{{ customer_engagement }}-project'
               description: 'Create project for {{ customer_engagement }}'


### PR DESCRIPTION
The infra-ansible role we are using expects this `ssh_key_data` key to be under `inputs.ssh_key_data`