### PR TITLE
Update rrule in tower_jobs_scheduled template to use better defaults and include timezone info.

### DIFF
--- a/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
+++ b/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
@@ -4,6 +4,8 @@ start_date: "{{ (start_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%
 end_date: "{{ (end_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
 archive_date: "{{ (archive_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
 
+timezone: "{{ timezone | default('UTC') }}"
+
 delete_missing_items: false
 
 ansible_tower:

--- a/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
+++ b/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
@@ -4,7 +4,7 @@ start_date: "{{ (start_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%
 end_date: "{{ (end_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
 archive_date: "{{ (archive_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
 
-timezone: "{{ timezone | default('UTC') }}"
+timezone: "{{ timezone | default("UTC") }}"
 
 delete_missing_items: false
 
@@ -56,7 +56,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-welcome-internal"
       description: "Welcome Internal for internal {{ company_name }} engagement members"
       {% raw -%}
-      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -67,7 +67,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-welcome-all"
       description: "Welcome notification for {{ company_name }} and {{ customer_name }}"
       {% raw -%}
-      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -78,7 +78,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-pre-offboard"
       description: "Pre-offboard"
       {% raw -%}
-      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=1) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=1) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -89,7 +89,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-1"
       description: "Offboard 1"
       {% raw -%}
-      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | add_time(days=3) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | add_time(days=3) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -100,7 +100,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-2"
       description: "Offboard 2"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=3) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=3) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -111,7 +111,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-3"
       description: "Offboard 3"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=2) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=2) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -122,7 +122,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-shutoff"
       description: "Shutoff e-mail for the {{ customer_engagement }} engagement"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone={{ timezone }}) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}

--- a/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
+++ b/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
@@ -56,7 +56,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-welcome-internal"
       description: "Welcome Internal for internal {{ company_name }} engagement members"
       {% raw -%}
-      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -67,7 +67,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-welcome-all"
       description: "Welcome notification for {{ company_name }} and {{ customer_name }}"
       {% raw -%}
-      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -78,7 +78,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-pre-offboard"
       description: "Pre-offboard"
       {% raw -%}
-      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=1) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=1) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -89,7 +89,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-1"
       description: "Offboard 1"
       {% raw -%}
-      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | add_time(days=3) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | add_time(days=3) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -100,7 +100,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-2"
       description: "Offboard 2"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=3) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=3) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -111,7 +111,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-3"
       description: "Offboard 3"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=2) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=2) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -122,7 +122,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-shutoff"
       description: "Shutoff e-mail for the {{ customer_engagement }} engagement"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone={{ timezone }}) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}

--- a/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
+++ b/inventory-generation/tower_jobs_schedules/templates/tower-management-host.yaml.j2
@@ -21,7 +21,7 @@ ansible_tower:
       scm_update_on_launch: true
   job_templates:
     - name: "{{ customer_engagement }}-email-notify-list-of-users"
-      description: "Job Template to send email notificaitons to users"
+      description: "Job Template to send email notifications to users"
       inventory: "{{ customer_engagement }}-tower-mail-host"
       project: "infra-ansible"
       playbook: "playbooks/notifications/email-notify-list-of-users.yml"
@@ -54,7 +54,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-welcome-internal"
       description: "Welcome Internal for internal {{ company_name }} engagement members"
       {% raw -%}
-      rrule: "{{ start_date | parse_datetime | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -65,7 +65,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-welcome-all"
       description: "Welcome notification for {{ company_name }} and {{ customer_name }}"
       {% raw -%}
-      rrule: "{{ start_date | parse_datetime | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ start_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -76,7 +76,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-pre-offboard"
       description: "Pre-offboard"
       {% raw -%}
-      rrule: "{{ end_date | parse_datetime | subtract_time(weeks=1) | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=1) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -87,7 +87,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-1"
       description: "Offboard 1"
       {% raw -%}
-      rrule: "{{ end_date | parse_datetime | add_time(days=3) | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ end_date | parse_datetime | replace_datetime(hour=5) | add_time(days=3) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -98,7 +98,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-2"
       description: "Offboard 2"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | subtract_time(weeks=3) | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=3) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -109,7 +109,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-offboard-3"
       description: "Offboard 3"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | subtract_time(weeks=2) | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | subtract_time(weeks=2) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}
@@ -120,7 +120,7 @@ ansible_tower:
     - name: "{{ customer_engagement }}-shutoff"
       description: "Shutoff e-mail for the {{ customer_engagement }} engagement"
       {% raw -%}
-      rrule: "{{ archive_date | parse_datetime | to_rrule(freq=3, interval=1, count=1) }}"
+      rrule: "{{ archive_date | parse_datetime | replace_datetime(hour=5) | to_rrule(timezone=timezone) }}"
       {%- endraw %}
       unified_job_template: "{{ customer_engagement }}-email-notify-list-of-users"
       enabled: {{ enable_notifications | default(false) }}


### PR DESCRIPTION
Relates to https://github.com/redhat-cop/infra-ansible/pull/619

The updated `to_rrule` filter includes defaults options on the frequency, interval, and count and now allows for timezones to be added to the final RRULE before it is sent to the Ansible Tower API.