### PR TITLE
Enable multiple hosting environments

### DIFF
--- a/inventory-generation/identity-management/main.yml
+++ b/inventory-generation/identity-management/main.yml
@@ -58,74 +58,11 @@
     set_fact:
       cc_list: "{{ ', '.join(( '{{ engagement_lead_email }}', '{{ technical_lead_email }}' )) }}"
 
-  #####################################################################################################################
-  # Right now, the only supported configuration is a list of one hosting environment.
-  # In the near future, this should be updated to support more than one, and this comment (and the code below)
-  # should be updated to support this. For now, this checking is just looking for more than zero hosting environments,
-  # but will default to use the value(s) from the first one.
-
   - block:
-    - name: "Set IDM facts"
-      set_fact:
-        ipa_host: "{{ 'ipa.apps.' + (hosting_environments[0].ocp_sub_domain | lower) + '.' + engagement_region | default('dev') + '-1.' + ocp_base_url }}"
-        ipa_admin_user: "{{ ocp_admin_username }}"
-        ipa_admin_password: "{{ ocp_admin_password }}"
-        ipa_validate_certs: "{{ ipa_validate_certs | default(true) }}"
-
-    - name: "Assemble inventory"
-      set_fact:
-        claim_content:
-          env_end_date: "{{ (archive_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
-          end_date: "{{ (end_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
-          start_date: "{{ (start_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
-          customer_name: "{{ customer_name }}"
-          project_name: "{{ project_name }}"
-          ipa_validate_certs: "{{ ipa_validate_certs }}"
-          ipa_host: "{{ ipa_host }}"
-          ipa_admin_user: "{{ ipa_admin_user }}"
-          ipa_admin_password: "{{ ipa_admin_password }}"
-          list_of_mail_cc: "{{ cc_list }}"
-          lodestar_identities:
-            users: "{{ users }}"
-            groups: "{{ usrgrp }}"
-
-    - name: "Check For Existing Inventory File"
-      stat:
-        path: "{{ directory }}/iac/inventories/identity-management/inventory/group_vars/all.yml"
-      register: existing_inv
-
-    - name: "Pull existing inventory vars"
-      include_vars:
-        file: "{{ directory }}/iac/inventories/identity-management/inventory/group_vars/all.yml"
-        name: existing_inv_contents
-      when:
-        - existing_inv.stat.exists
-
-    - name: "Diff existing vars with new inventory"
-      set_fact:
-        inv_has_diff: true
-      when:
-        - existing_inv.stat.exists
-        - existing_inv_contents is defined
-        - existing_inv_contents != (claim_content | from_yaml)
-
-    - name: "Write inventory to file"
-      copy:
-        content: "{{ claim_content | to_nice_yaml(indent=2) }}"
-        dest: "{{ directory }}/iac/inventories/identity-management/inventory/group_vars/all.yml"
-
-    - name: "Create hosts file"
-      copy:
-        content: "[identity-hosts]\nlocalhost"
-        dest: "{{ directory }}/iac/inventories/identity-management/inventory/hosts"
-
-    - name: "Create ResourceClaim"
-      copy:
-        content: "{{ lookup('template', inventory_dir + '/../files/templates/resourceclaim.yaml.j2') }}"
-        dest: "{{ directory }}/ocp-init/id-mgmt-{{ inv_ts | trim }}.yaml"
-      when:
-        - (inv_has_diff is defined and inv_has_diff is true) or not existing_inv.stat.exists
+      - include_tasks: tasks/envs.yaml
+        with_items: "{{ hosting_environments }}"
+        loop_control:
+          loop_var: hosting_env 
     when:
       - hosting_environments is defined
       - hosting_environments|length > 0
-      - hosting_environments[0].ocp_sub_domain is defined

--- a/inventory-generation/identity-management/tasks/envs.yaml
+++ b/inventory-generation/identity-management/tasks/envs.yaml
@@ -1,0 +1,72 @@
+---
+
+- block:
+  - name: "Set IDM facts"
+    set_fact:
+      ipa_host: "{{ 'ipa.apps.' + (hosting_env.ocp_sub_domain | lower) + '.' + engagement_region | default('dev') + '-1.' + ocp_base_url }}"
+      ipa_admin_user: "{{ ocp_admin_username }}"
+      ipa_admin_password: "{{ ocp_admin_password }}"
+      ipa_validate_certs: "{{ ipa_validate_certs | default(true) }}"
+
+  - name: "Assemble inventory"
+    set_fact:
+      claim_content:
+        env_end_date: "{{ (archive_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
+        end_date: "{{ (end_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
+        start_date: "{{ (start_date | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%d %b %Y') }}"
+        customer_name: "{{ customer_name }}"
+        project_name: "{{ project_name }}"
+        ipa_validate_certs: "{{ ipa_validate_certs }}"
+        ipa_host: "{{ ipa_host }}"
+        ipa_admin_user: "{{ ipa_admin_user }}"
+        ipa_admin_password: "{{ ipa_admin_password }}"
+        list_of_mail_cc: "{{ cc_list }}"
+        lodestar_identities:
+          users: "{{ users }}"
+          groups: "{{ usrgrp }}"
+
+  - name: "Check For Existing Inventory File"
+    stat:
+      path: "{{ directory }}/iac/inventories/identity-management/inventory/host_vars/{{ hosting_env.ocp_sub_domain }}.yml"
+    register: existing_inv
+
+  - name: "Pull existing inventory vars"
+    include_vars:
+      file: "{{ directory }}/iac/inventories/identity-management/inventory/host_vars/{{ hosting_env.ocp_sub_domain }}.yml"
+      name: existing_inv_contents
+    when:
+      - existing_inv.stat.exists
+
+  - name: "Diff existing vars with new inventory"
+    set_fact:
+      inv_has_diff: true
+    when:
+      - (existing_inv.stat.exists and existing_inv_contents is defined and existing_inv_contents != (claim_content | from_yaml)) or not existing_inv.stat.exists
+
+  - name: "Ensure path exists"
+    file:
+      state: "directory"
+      path: "{{ directory }}/iac/inventories/identity-management/inventory/host_vars"
+
+  - name: "Write inventory to file"
+    copy:
+      content: "{{ claim_content | to_nice_yaml(indent=2) }}"
+      dest: "{{ directory }}/iac/inventories/identity-management/inventory/host_vars/{{ hosting_env.ocp_sub_domain }}.yml"
+    when:
+      - (inv_has_diff is defined and inv_has_diff is true) or not existing_inv.stat.exists
+
+  - name: "Create hosts file"
+    copy:
+      content: "[identity-hosts]\nlocalhost"
+      dest: "{{ directory }}/iac/inventories/identity-management/inventory/hosts"
+    when:
+      - (inv_has_diff is defined and inv_has_diff is true) or not existing_inv.stat.exists
+
+  - name: "Create ResourceClaim"
+    copy:
+      content: "{{ lookup('template', inventory_dir + '/../files/templates/resourceclaim.yaml.j2') }}"
+      dest: "{{ directory }}/ocp-init/id-mgmt-{{ (hosting_env.ocp_sub_domain |  trim) | lower }}-{{ inv_ts | trim }}.yaml"
+    when:
+      - (inv_has_diff is defined and inv_has_diff is true)
+  when:
+    - hosting_env.ocp_sub_domain is defined

--- a/translate-engagement-data/site.yml
+++ b/translate-engagement-data/site.yml
@@ -13,39 +13,10 @@
       when:
         - (governor_type is undefined or (governor_type | trim) == "") or (governor_spec is undefined or (governor_spec | trim) == "")
     - block:
-      - name: Set fact used to check if a hosting environment is needed
-        set_fact:
-          ocp_cloud_provider_name: "{{ hosting_environments[0].ocp_cloud_provider_name | default('other') }}"
-      - block:
-        - name: Read credentials
-          include_vars:
-            file: "{{ directory }}/{{ config_dir }}/{{ item }}"
-          loop:
-            - "ocp-admin-credentials.json"
-            - "ocp-ldap-sa-credentials.json"
-        - name: Create OCP manifest directory if not present
-          file:
-            path: "{{ directory }}/ocp-init"
-            state: directory
-        - name: Create Resource Claim
-          vars:
-            claim_content:
-              email: "{{ engagement_lead_email }}"
-              admin_user: "{{ ocp_admin_username }}"
-              admin_password: "{{ ocp_admin_password }}"
-              aws_region: "{{ hosting_environments[0].ocp_cloud_provider_region }}"
-              customer_name: "{{ customer_name }}"
-              customer_project: "{{ project_name }}"
-              engagement_uuid: "{{ uuid }}"
-              ocp4_installer_version: "{{ hosting_environments[0].ocp_version }}"
-              ocp_ldap_sa_user: "{{ ocp_ldap_sa_username }}"
-              ocp_ldap_sa_password: "{{ ocp_ldap_sa_password }}"
-              ocp_subdomain: "{{ hosting_environments[0].ocp_sub_domain }}"
-          copy:
-            content: "{{ lookup('template', inventory_dir + '/../files/templates/resourceclaim.yaml.j2') }}"
-            dest: "{{ directory }}/ocp-init/cluster-init.yaml"
-        when:
-          - ocp_cloud_provider_name|trim != 'other'
+      - include_tasks: tasks/envs.yaml
+        with_items: "{{ hosting_environments }}"
+        loop_control:
+          loop_var: hosting_env
       when:
         - hosting_environments is defined
         - hosting_environments|length > 0

--- a/translate-engagement-data/tasks/envs.yaml
+++ b/translate-engagement-data/tasks/envs.yaml
@@ -1,0 +1,36 @@
+---
+
+- name: Set fact used to check if a hosting environment is needed
+  set_fact:
+    ocp_cloud_provider_name: "{{ hosting_env.ocp_cloud_provider_name | default('other') }}"
+
+- block:
+    - name: Read credentials
+      include_vars:
+        file: "{{ directory }}/{{ config_dir }}/{{ item }}"
+      loop:
+        - "ocp-admin-credentials.json"
+        - "ocp-ldap-sa-credentials.json"
+    - name: Create OCP manifest directory if not present
+      file:
+        path: "{{ directory }}/ocp-init"
+        state: directory
+    - name: Create Resource Claim
+      vars:
+        claim_content:
+          email: "{{ engagement_lead_email }}"
+          admin_user: "{{ ocp_admin_username }}"
+          admin_password: "{{ ocp_admin_password }}"
+          aws_region: "{{ hosting_env.ocp_cloud_provider_region }}"
+          customer_name: "{{ customer_name }}"
+          customer_project: "{{ project_name }}"
+          engagement_uuid: "{{ uuid }}"
+          ocp4_installer_version: "{{ hosting_env.ocp_version }}"
+          ocp_ldap_sa_user: "{{ ocp_ldap_sa_username }}"
+          ocp_ldap_sa_password: "{{ ocp_ldap_sa_password }}"
+          ocp_subdomain: "{{ hosting_env.ocp_sub_domain }}"
+      copy:
+        content: "{{ lookup('template', inventory_dir + '/../files/templates/resourceclaim.yaml.j2') }}"
+        dest: "{{ directory }}/ocp-init/cluster-init-{{ (hosting_env.environment_name |  trim) | regex_replace(' ','-') | lower }}.yaml"
+  when:
+    - ocp_cloud_provider_name|trim != 'other'

--- a/translate-engagement-data/tasks/envs.yaml
+++ b/translate-engagement-data/tasks/envs.yaml
@@ -31,6 +31,6 @@
           ocp_subdomain: "{{ hosting_env.ocp_sub_domain }}"
       copy:
         content: "{{ lookup('template', inventory_dir + '/../files/templates/resourceclaim.yaml.j2') }}"
-        dest: "{{ directory }}/ocp-init/cluster-init-{{ (hosting_env.environment_name |  trim) | regex_replace(' ','-') | lower }}.yaml"
+        dest: "{{ directory }}/ocp-init/cluster-init-{{ (hosting_env.ocp_sub_domain |  trim) | lower }}.yaml"
   when:
     - ocp_cloud_provider_name|trim != 'other'


### PR DESCRIPTION
I believe this is all that is needed on the automation/orchestration side to support multiple hosting environments. Some minor cleanup required at a later date when we decide to start doing more than AWS hosting environments as there is still a `-1` hard-coded in the `translate-engagement-data` automation.

cc/ @oybed @jfilipcz 

Leaving this as a draft as I'd like to hold off on merging until we get our current changes moved through the environments.