### PR TITLE
Set allow_simultaneous to false on job template

### DIFF
--- a/inventory-generation/tower_jobs_launch/main.yaml
+++ b/inventory-generation/tower_jobs_launch/main.yaml
@@ -75,6 +75,7 @@
               project: infra-ansible
               playbook: playbooks/ansible/tower/configure-ansible-tower.yml
               ask_inventory: yes
+              allow_simultaneous: false
           launch_jobs:
             - name: Launch Tower Job to configure Scheduled Notifications
               job_template: '{{ customer_engagement }}-configure-ansible-tower'


### PR DESCRIPTION
This PR is a follow up and depends on https://github.com/redhat-cop/infra-ansible/pull/626 to be able to disable concurrent jobs in Ansible Tower. This will allow only 1 configure-ansible-tower job to be run per engagement at any given time.