### PR TITLE
Update manage-participants playbook

### DIFF
--- a/inventory-generation/identity-management/main.yml
+++ b/inventory-generation/identity-management/main.yml
@@ -112,11 +112,6 @@
                 ssh_key: "{{ ( repository_ssh_key | to_nice_yaml( default_style='>-', indent=4, width=5000 ) | trim) if repository_ssh_key is defined else omit }}"
                 username: "{{ repository_username if repository_username is defined else omit }}"
                 password: "{{ repository_password if repository_password is defined else omit }}"
-              git:
-                name: "{{ git.name if git.name is defined else omit }}"
-                username: "{{ git.username if git.username is defined else omit }}"
-                email: "{{ git.email if git.email is defined else omit }}"
-                message: "{{ git.message if git.message is defined else omit }}"
 
         - name: "Check For Existing Inventory File"
           stat:

--- a/manage-participants/completion_callback.yml
+++ b/manage-participants/completion_callback.yml
@@ -19,8 +19,8 @@
 
     - name: Attempt completion callback
       when:
-      - agnosticd_callback_url != ''
-      - agnosticd_callback_token != ''
+        - agnosticd_callback_url != ''
+        - agnosticd_callback_token != ''
       vars:
         user_body_yaml: "{{ output_dir ~ '/user-body.yaml' }}"
         user_data_yaml: "{{ output_dir ~ '/user-data.yaml' }}"

--- a/manage-participants/completion_callback.yml
+++ b/manage-participants/completion_callback.yml
@@ -6,6 +6,9 @@
 - name: Completion Callback
   gather_facts: false
   hosts: localhost
+  vars:
+    agnosticd_callback_url: "{{ agnosticd_callback_url | default('') }}"
+    agnosticd_callback_token: "{{ agnosticd_callback_token | default('') }}"
   tasks:
 
     - name: Skip completion callback
@@ -16,8 +19,8 @@
 
     - name: Attempt completion callback
       when:
-        - agnosticd_callback_url != ''
-        - agnosticd_callback_token != ''
+      - agnosticd_callback_url != ''
+      - agnosticd_callback_token != ''
       vars:
         user_body_yaml: "{{ output_dir ~ '/user-body.yaml' }}"
         user_data_yaml: "{{ output_dir ~ '/user-data.yaml' }}"
@@ -48,6 +51,6 @@
             {%- endif -%}
         headers:
           Authorization: Bearer {{ agnosticd_callback_token }}
-        validate_certs: "{{ validate_tower_certs | default(true) }}"
+        validate_certs: "{{ validate_tower_certs | default(yes) }}"
       # Best effort
       ignore_errors: true

--- a/manage-participants/destroy.yml
+++ b/manage-participants/destroy.yml
@@ -42,15 +42,15 @@
         - lodestar_identities.users is defined
         - lodestar_identities.users != []
 
-- name: Remove participants from IdM
+- name: Remove all participants from IdM
   import_playbook: "../../requirements_roles/infra-ansible/playbooks/manage-identities/manage-idm-identities.yml"
   vars:
-    identities: "{{ lodestar_identities_remove }}"
+    identities: "{{ lodestar_identities }}"
   when:
-    - lodestar_identities_remove.users is defined
-    - lodestar_identities_remove.users != []
+    - lodestar_identities.users is defined
+    - lodestar_identities.users != []
 
-- name: Remove participants from queue
+- name: Ensure queue is cleared
   import_playbook: "process_queue.yml"
   when:
     - lodestar_identities_remove.users is defined

--- a/manage-participants/destroy.yml
+++ b/manage-participants/destroy.yml
@@ -15,19 +15,46 @@
       when:
         - ipa_host is defined
 
+- hosts: identity-hosts
+  name: Process Identity removal list
+  tasks:
+
+    - name: Create empty removal list
+      set_fact:
+        lodestar_identities_remove:
+          users: []
+
+    - name: Add users to removal list
+      set_fact:
+        lodestar_identities_remove:
+          users: "{{ lodestar_identities_remove.users + [ user_info ] }}"
+      vars:
+        user_info:
+          first_name: "{{ identity.first_name | trim }}"
+          last_name: "{{ identity.last_name | trim }}"
+          email: "{{ identity.email | trim }}"
+          user_name: "{{ identity.email.split('@')[0] | trim }}"
+          state: "absent"
+      with_items: "{{ lodestar_identities.users }}"
+      loop_control:
+        loop_var: identity
+      when:
+        - lodestar_identities.users is defined
+        - lodestar_identities.users != []
+
 - name: Remove participants from IdM
   import_playbook: "../../requirements_roles/infra-ansible/playbooks/manage-identities/manage-idm-identities.yml"
   vars:
-    identities: "{{ lodestar_identities }}"
+    identities: "{{ lodestar_identities_remove }}"
   when:
-    - lodestar_identities_remove is defined
-    - lodestar_identities_remove != []
+    - lodestar_identities_remove.users is defined
+    - lodestar_identities_remove.users != []
 
-- name: Remove partitipants from queue
+- name: Remove participants from queue
   import_playbook: "process_queue.yml"
   when:
-    - lodestar_identities_remove is defined
-    - lodestar_identities_remove != []
+    - lodestar_identities_remove.users is defined
+    - lodestar_identities_remove.users != []
 
 - name: Update Anarchy with status
   import_playbook: completion_callback.yml

--- a/manage-participants/mail_users.yml
+++ b/manage-participants/mail_users.yml
@@ -1,0 +1,15 @@
+---
+
+- hosts: mail-host
+  gather_facts: false
+  tasks:
+
+    - name: "Include additional variables / inventory content"
+      include_vars:
+        file: "{{ item }}"
+      with_items: "{{ email_template | fileglob }}"
+
+- name: Notify users
+  import_playbook: "../../requirements_roles/infra-ansible/playbooks/notifications/email-notify-users.yml"
+  vars:
+    users: "{{ identities.users }}"

--- a/manage-participants/main.yml
+++ b/manage-participants/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: localhost
-  name: Verify Identity Provider
+  name: Verify Identity Provider and setup dependencies
   tasks:
 
     - name: Wait for IdM to be responsive
@@ -20,32 +20,22 @@
   vars:
     identities: "{{ lodestar_identities_remove }}"
   when:
-    - lodestar_identities_remove is defined
-    - lodestar_identities_remove != []
+    - lodestar_identities_remove.users is defined
+    - lodestar_identities_remove.users != []
 
-- name: Remove partitipants from queue
+- name: Remove participants from queue
   import_playbook: "process_queue.yml"
   when:
-    - lodestar_identities_remove is defined
-    - lodestar_identities_remove != []
+    - lodestar_identities_remove.users is defined
+    - lodestar_identities_remove.users != []
 
 - name: Add participants to IdM
   import_playbook: "../../requirements_roles/infra-ansible/playbooks/manage-identities/manage-idm-identities.yml"
   vars:
     identities: "{{ lodestar_identities }}"
 
-- hosts: mail-host
-  gather_facts: false
-  tasks:
-    - name: "Include additional variables / inventory content"
-      include_vars:
-        file: "{{ item }}"
-      with_items: "{{ email_template | fileglob }}"
-
-- name: Notify users
-  import_playbook: "../../requirements_roles/infra-ansible/playbooks/notifications/email-notify-users.yml"
-  vars:
-    users: "{{ identities.users }}"
+- name: Mail Users
+  import_playbook: mail_users.yml
 
 - name: Update Anarchy with status
   import_playbook: completion_callback.yml

--- a/manage-participants/null.yml
+++ b/manage-participants/null.yml
@@ -1,0 +1,11 @@
+---
+# vim: set ft=ansible:
+
+################################################################################
+# Entry point used to send a completion callback and ends the playbook without action
+################################################################################
+
+- import_playbook: completion_callback.yml
+
+- name: End Playbook
+  meta: end_play

--- a/manage-participants/process_queue.yml
+++ b/manage-participants/process_queue.yml
@@ -36,14 +36,6 @@
       when:
         - emails_to_match is defined
 
-    - name: "Capture processed filenames"
-      set_fact:
-        processed_files: "{{ ( processed_files | default('') ) + ( filepath | basename ) + ',' }}"
-      loop_control:
-        loop_var: filepath
-      with_items:
-        - "{{ files_to_remove }}"
-
     - name: "Push git repository"
       include_role:
         name: "../../requirements_roles/infra-ansible/roles/scm/git"
@@ -53,10 +45,19 @@
           name: Git Bot
           username: git-bot
           email: git-bot@no-reply
-          message: "Removed processed files\n\n{{ processed_files }}"
+          message: |
+            Removed processed files
+
+            The following files were removed from the job queue
+
+            {% for file in files_to_remove %}
+            - {{ file | basename }}
+            {% endfor %}
           remove_local: false
       when:
         - repository is defined
+        - files_to_remove is defined
+        - files_to_remove != []
 
     - name: Pre-populate identities
       set_fact:

--- a/manage-participants/process_queue.yml
+++ b/manage-participants/process_queue.yml
@@ -36,11 +36,25 @@
       when:
         - emails_to_match is defined
 
+    - name: "Capture processed filenames"
+      set_fact:
+        processed_files: "{{ ( processed_files | default('') ) + ( filepath | basename ) + ',' }}"
+      loop_control:
+        loop_var: filepath
+      with_items:
+        - "{{ files_to_remove }}"
+
     - name: "Push git repository"
       include_role:
         name: "../../requirements_roles/infra-ansible/roles/scm/git"
       vars:
         action: push
+        git_config:
+          name: Git Bot
+          username: git-bot
+          email: git-bot@no-reply
+          message: "Removed processed files\n\n{{ processed_files }}"
+          remove_local: false
       when:
         - repository is defined
 

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,22 +1,6 @@
 ---
-##################################################
-# Requirements (Roles)
-##################################################
 
-collections: []
-
-roles:
-  - name: infra-ansible
-    scm: git
-
-    # TODO: Phase 1: Run from fork
-    src: https://github.com/MAHDTech/infra-ansible
-    version: feature/user-reset
-
-    # TODO: Phase 2: Run from main
-    #src: https://github.com/redhat-cop/infra-ansible
-    #version: main
-
-    # TODO: Phase 3: Run from release
-    #src: https://github.com/redhat-cop/infra-ansible
-    #version: v2.0.4
+- name: infra-ansible
+  scm: git
+  src: https://github.com/redhat-cop/infra-ansible
+  version: main


### PR DESCRIPTION
This PR adds the following;

- Add null entrypoint for optional usage in the event you want to stop a task from making changes 
- Check callback url & token are both defined, not null and set a default 
- Iterate over correct list of users to remove on ResourceClaim deletion
- Use old requirements format for dependencies to work with older ansible-cli version.
- Align `git_config` variable name with infra-ansible role and set generic default
