### PR TITLE
Manage Participants: Fix callbacks and destroy

### DIFF
--- a/inventory-generation/identity-management/queue/user-management.yml
+++ b/inventory-generation/identity-management/queue/user-management.yml
@@ -1,19 +1,16 @@
 ---
+
 - name: "Read User Management Job: {{ job.path | basename }}"
   include_vars:
     file: "{{ job.path }}"
 
-- name: "Display User Management Job Details"
-  debug:
-    msg:
-      - "Adding the follow user details to the removal list"
-      - "User ID: {{ uuid }}"
-      - "First Name: {{ first_name }}"
-      - "Last Name: {{ last_name }}"
-      - "Email: {{ email }}"
-      - "Role: {{ role }}"
-      - "State: absent"
-
 - name: "Add User to removal queue"
   set_fact:
-    users_remove: "{{ (users_remove | default([])) + [ { 'first_name': (first_name | trim), 'last_name': (last_name | trim), 'email': (email | trim) , 'user_name': (email.split('@')[0] | trim), 'state': 'absent' } ] }}"
+    users_remove: "{{ (users_remove | default([])) + [ user_info ] }}"
+  vars:
+    user_info:
+      first_name: "{{ first_name | trim }}"
+      last_name: "{{ last_name | trim }}"
+      email: "{{ email | trim }}"
+      user_name: "{{ email.split('@')[0] | trim }}"
+      state: "absent"

--- a/manage-participants/completion_callback.yml
+++ b/manage-participants/completion_callback.yml
@@ -7,8 +7,11 @@
   gather_facts: false
   hosts: localhost
   vars:
-    agnosticd_callback_url: "{{ agnosticd_callback_url | default('') }}"
-    agnosticd_callback_token: "{{ agnosticd_callback_token | default('') }}"
+    # default __meta__ to prevent errors on older ansible versions
+    __meta__:
+      callback: {}
+    agnosticd_callback_url: "{{ __meta__.callback.url | default('') }}"
+    agnosticd_callback_token: "{{ __meta__.callback.token | default('') }}"
   tasks:
 
     - name: Skip completion callback
@@ -51,6 +54,6 @@
             {%- endif -%}
         headers:
           Authorization: Bearer {{ agnosticd_callback_token }}
-        validate_certs: "{{ validate_tower_certs | default(yes) }}"
+        validate_certs: "{{ validate_tower_certs | default(true) }}"
       # Best effort
       ignore_errors: true

--- a/manage-participants/destroy.yml
+++ b/manage-participants/destroy.yml
@@ -15,19 +15,13 @@
       when:
         - ipa_host is defined
 
-- hosts: identity-hosts
-  name: Process Identity removal list
-  tasks:
-
-    - name: Create empty removal list
+    - name: Create empty user removal list
       set_fact:
-        lodestar_identities_remove:
-          users: []
+        users_remove: []
 
-    - name: Add users to removal list
+    - name: Add all users to removal list
       set_fact:
-        lodestar_identities_remove:
-          users: "{{ lodestar_identities_remove.users + [ user_info ] }}"
+        users_remove: "{{ users_remove + [ user_info ] }}"
       vars:
         user_info:
           first_name: "{{ identity.first_name | trim }}"
@@ -42,15 +36,20 @@
         - lodestar_identities.users is defined
         - lodestar_identities.users != []
 
-- name: Remove all participants from IdM
+    - name: Update user removal list
+      set_fact:
+        lodestar_identities_destroy:
+          users: "{{ users_remove }}"
+
+- name: Remove participants from IdM
   import_playbook: "../../requirements_roles/infra-ansible/playbooks/manage-identities/manage-idm-identities.yml"
   vars:
-    identities: "{{ lodestar_identities }}"
+    identities: "{{ lodestar_identities_destroy }}"
   when:
-    - lodestar_identities.users is defined
-    - lodestar_identities.users != []
+    - lodestar_identities_destroy.users is defined
+    - lodestar_identities_destroy.users != []
 
-- name: Ensure queue is cleared
+- name: Remove participants from queue
   import_playbook: "process_queue.yml"
   when:
     - lodestar_identities_remove.users is defined

--- a/manage-participants/main.yml
+++ b/manage-participants/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: localhost
-  name: Verify Identity Provider and setup dependencies
+  name: Verify Identity Provider
   tasks:
 
     - name: Wait for IdM to be responsive
@@ -25,6 +25,8 @@
 
 - name: Remove participants from queue
   import_playbook: "process_queue.yml"
+  vars:
+    identities: "{{ lodestar_identities_remove }}"
   when:
     - lodestar_identities_remove.users is defined
     - lodestar_identities_remove.users != []
@@ -33,9 +35,14 @@
   import_playbook: "../../requirements_roles/infra-ansible/playbooks/manage-identities/manage-idm-identities.yml"
   vars:
     identities: "{{ lodestar_identities }}"
+  when:
+    - lodestar_identities.users is defined
+    - lodestar_identities.users != []
 
 - name: Mail Users
   import_playbook: mail_users.yml
+  vars:
+    identities: "{{ lodestar_identities }}"
 
 - name: Update Anarchy with status
   import_playbook: completion_callback.yml

--- a/manage-participants/process_queue.yml
+++ b/manage-participants/process_queue.yml
@@ -20,7 +20,7 @@
       set_fact:
         emails_to_match: "{{ (emails_to_match | default([])) + [ user.email ] }}"
       loop:
-        "{{ lodestar_identities_remove.users | flatten(levels=1) }}"
+        "{{ identities.users | flatten(levels=1) }}"
       loop_control:
         index_var: index
         loop_var: user
@@ -58,7 +58,3 @@
         - repository is defined
         - files_to_remove is defined
         - files_to_remove != []
-
-    - name: Pre-populate identities
-      set_fact:
-        identities: "{{ lodestar_identities }}"


### PR DESCRIPTION
Includes a few fixes to the manage-participants playbook;

- Use previous `__meta__` var names
- Use true for boolean
- 🤦 Undo incorrect variable name change
- Build user_remove list items individually
- Standardize on using the same 'identities' var name consistently
- Remove single line users_remove in favor of easier to read vars
