### PR TITLE
Use new Poolboy ResourceProviders

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -11,7 +11,7 @@ spec:
       kind: AnarchySubject
       metadata:
         annotations:
-          poolboy.gpte.redhat.com/resource-provider-name: babylon
+          poolboy.gpte.redhat.com/resource-provider-name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}
         generateName: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}-{{ claim_postfix | default("") }}
         labels:
           governor: "{{ (engagement_type | lower) +'.' + (governor_type | lower) + '.' + (governor_spec | lower) }}"


### PR DESCRIPTION
# Overview

The cluster wide `babylon` Poolboy ResourceProvider is being deprecated in favour of individual ResourceProviders that are created by the AgnosticV Operator.

This PR changes any newly created ResourceClaim objects to use the annotation that matches these new ResourceProviders. Note that these ResourceClaims that include the annotation are created during Resource Dispatchers `d2-daily` and `translate_engagement_data` schedules.

For example, given these example catalog items

| Catalog Name | Old | New |
| :-----------: | :--: | :--: |
| do500.day2.idm | babylon | do500.day2.idm |
| do500.ocp4.dev | babylon | do500.ocp4.dev |
| labs.day2.idm | babylon | labs.day2.idm |
| labs.ocp4.dev | babylon | labs.ocp4.dev |
| residency.day2.idm | babylon | residency.day2.idm |
| residency.ocp4.dev | babylon | residency.ocp4.dev |

This change is required as a dependency as part of the user reset functionality which requires custom `updateFilters` to be applied. See the following references for further information.

- [Old method](https://github.com/redhat-cop/poolboy/pull/64)
- [New method](https://github.com/redhat-gpte-devopsautomation/agnosticv-operator/pull/89)
- [Internal example config](https://gitlab.consulting.redhat.com/rht-labs/scratch/lodestar-sandbox/maduncan/lodestar-config/-/blob/trunk/agnosticv/residency/day2/common.yaml#L15)
- [Internal chat thread](https://chat.google.com/room/AAAA9Rwqf0c/zm-uoOMRBxE)

