### PR TITLE
Revert ResourceProvider name

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -11,7 +11,7 @@ spec:
       kind: AnarchySubject
       metadata:
         annotations:
-          poolboy.gpte.redhat.com/resource-provider-name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}
+          poolboy.gpte.redhat.com/resource-provider-name: babylon
         generateName: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}-{{ claim_postfix | default("") }}
         labels:
           governor: "{{ (engagement_type | lower) +'.' + (governor_type | lower) + '.' + (governor_spec | lower) }}"


### PR DESCRIPTION
This PR reverts the usage of individual ResourceProviders until the upstream feature is merged from [#89](https://github.com/redhat-gpte-devopsautomation/agnosticv-operator/pull/89).

A future PR will re-enable that and bump the AgnosticV Operator version to suit enablement.