### PR TITLE
Use new Poolboy ResourceProviders

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -6,12 +6,15 @@ metadata:
   name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}-{{ project_id }}
 spec:
   resources:
+    provider:
+      apiVersion: poolboy.gpte.redhat.com/v1
+      kind: ResourceProvider
+      name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}
+      namespace: lodestar-babylon-operators
   - template:
       apiVersion: anarchy.gpte.redhat.com/v1
       kind: AnarchySubject
       metadata:
-        annotations:
-          poolboy.gpte.redhat.com/resource-provider-name: babylon
         generateName: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}-{{ claim_postfix | default("") }}
         labels:
           governor: "{{ (engagement_type | lower) +'.' + (governor_type | lower) + '.' + (governor_spec | lower) }}"

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -9,7 +9,7 @@ spec:
     provider:
       apiVersion: poolboy.gpte.redhat.com/v1
       kind: ResourceProvider
-      name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}
+      name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}
       namespace: lodestar-babylon-operators
   - template:
       apiVersion: anarchy.gpte.redhat.com/v1


### PR DESCRIPTION
# Overview

This is attempt 2 at using the new Poolboy Resource Providers.

For background see;

- [Attempt 1](https://github.com/rht-labs/lodestar-automation/pull/73) (activate)
- [Attempt 1](https://github.com/rht-labs/lodestar-automation/pull/75) (revert)

For example implementation see;

- [service-provision](https://github.com/redhat-cop/babylon/blob/f3bc990faeb13e701ad2546a5573ff69d46dd77e/playbooks/service-provision.yaml#L211)

## Background

The cluster wide `babylon` Poolboy ResourceProvider is being deprecated in favour of individual ResourceProviders that are created by the AgnosticV Operator.

This PR changes any newly created ResourceClaim objects to use the new `provider` method in place of the previous `annotation` method.

For example, given these example catalog items

| Catalog Name | Old | New |
| :-----------: | :--: | :--: |
| do500.day2.idm | babylon | do500.day2.idm |
| do500.ocp4.dev | babylon | do500.ocp4.dev |
| labs.day2.idm | babylon | labs.day2.idm |
| labs.ocp4.dev | babylon | labs.ocp4.dev |
| residency.day2.idm | babylon | residency.day2.idm |
| residency.ocp4.dev | babylon | residency.ocp4.dev |
