### PR TITLE
Fix indent bug for resourceclaim 

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -10,7 +10,7 @@ spec:
       apiVersion: poolboy.gpte.redhat.com/v1
       kind: ResourceProvider
       name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}
-      namespace: lodestar-babylon-operators
+      namespace: {{ poolboy_namespace | default('lodestar-babylon-operators' }}
   - template:
       apiVersion: anarchy.gpte.redhat.com/v1
       kind: AnarchySubject

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -6,12 +6,12 @@ metadata:
   name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}-{{ project_id }}
 spec:
   resources:
-    provider:
+  - provider:
       apiVersion: poolboy.gpte.redhat.com/v1
       kind: ResourceProvider
       name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}
       namespace: {{ poolboy_namespace | default('lodestar-babylon-operators' }}
-  - template:
+    template:
       apiVersion: anarchy.gpte.redhat.com/v1
       kind: AnarchySubject
       metadata:

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -10,7 +10,7 @@ spec:
       apiVersion: poolboy.gpte.redhat.com/v1
       kind: ResourceProvider
       name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}
-      namespace: {{ poolboy_namespace | default('lodestar-babylon-operators') }}
+      namespace: lodestar-babylon-operators
     template:
       apiVersion: anarchy.gpte.redhat.com/v1
       kind: AnarchySubject

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -10,7 +10,7 @@ spec:
       apiVersion: poolboy.gpte.redhat.com/v1
       kind: ResourceProvider
       name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}
-      namespace: {{ poolboy_namespace | default('lodestar-babylon-operators' }}
+      namespace: {{ poolboy_namespace | default('lodestar-babylon-operators') }}
     template:
       apiVersion: anarchy.gpte.redhat.com/v1
       kind: AnarchySubject


### PR DESCRIPTION
This PR;

1. Adds a new variable that allows you to override the namespace where the ResourceProviders are looked to match the ResourceClaims.

This value can be provided via AgnosticV during execution and if not provided, defaults to `lodestar-babylon-operators`

One example use-case might be to setup AgnosticV as follows;

```yaml
poolboy_namespace: "{{ __meta__.anarchy.namespace }}"
```

2. Uses the correct indentation on the template to pass the OpenAPI specification.
