### PR TITLE
Remove legacy fields from ResourceClaim template

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -12,14 +12,7 @@ spec:
       name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}
       namespace: lodestar-babylon-operators
     template:
-      apiVersion: anarchy.gpte.redhat.com/v1
-      kind: AnarchySubject
-      metadata:
-        generateName: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower) }}-{{ claim_postfix | default("") }}
-        labels:
-          governor: "{{ (engagement_type | lower) +'.' + (governor_type | lower) + '.' + (governor_spec | lower) }}"
       spec:
-        governor: "{{ (engagement_type | lower) +'.' + (governor_type | lower) + '.' + (governor_spec | lower) }}"
         vars:
           {%- if desired_state is defined and desired_state|length %}
           desired_state: {{ desired_state }}


### PR DESCRIPTION
This PR removes the legacy fields from the generated `ResourceClaim` ensuring compatibility with the latest AgnosticV Operator OpenAPI specification that is validated within the `ResourceProvider`.

The latest OpenAPI specification from AgnosticV is as follows;

```yaml
validation:
    openAPIV3Schema:
      additionalProperties: false
      properties:
        spec:
          additionalProperties: false
          properties:
            vars:
              additionalProperties: false
              properties:
                action_schedule:
                  additionalProperties: false
                  properties:
                    start:
                      pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
                      type: string
                    stop:
                      pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
                      type: string
                  type: object
                job_vars:
                  additionalProperties: false
                  properties:
                    example_var:
                      description: This is an example job variable
                  required:
                  - example_var
                  type: object
              type: object
          required:
          - vars
          type: object
      required:
      - spec
      type: object
```

Without this change, the following error is displayed when applying the current templated `ResourceClaim` to an environment running the newer version of AgnosticV Operator.

```bash
lodestar-babylon-operators/poolboy-646cf8dcc9-k7fjz[manager]: {"message": "Validation failure for spec.resources[0].template: Additional properties are not allowed ('apiVersion', 'metadata', 'kind' were unexpected)\n\nFailed validating 'additionalProperties' in schema:\n    {'additionalProperties': False,\n     'nullable': False,\n     'properties': {'spec': {'additionalProperties': False,\n                             'properties': {'vars': {'additionalProperties': False,\n                                                     'properties': {'action_schedule': {'additionalProperties': False
lodestar-babylon-operators/poolboy-646cf8dcc9-k7fjz[manager]: {"message": "Validation failure for spec.resources[0].template: Additional properties are not allowed ('governor' was unexpected)\n\nFailed validating 'additionalProperties' in schema['properties']['spec']:\n    {'additionalProperties': False,\n     'nullable': False,\n     'properties': {'vars': {'additionalProperties': False,\n                             'properties': {'action_schedule': {'additionalProperties': False,\n
```