### PR TITLE
Add action_schedule to template

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -16,7 +16,7 @@ spec:
         vars:
           action_schedule:
             start: "{{ timestamp.utcnow }}"
-            stop: "{{ timestamp.utcnow.add('2h') }}"
+            stop: "{{ timestamp.utcnow.add('4h') }}"
           {%- if desired_state is defined and desired_state|length %}
           desired_state: {{ desired_state }}
           {%- endif %}

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -14,6 +14,9 @@ spec:
     template:
       spec:
         vars:
+          action_schedule:
+            start: "{{ timestamp.utcnow }}"
+            stop: "{{ timestamp.utcnow.add('2h') }}"
           {%- if desired_state is defined and desired_state|length %}
           desired_state: {{ desired_state }}
           {%- endif %}


### PR DESCRIPTION
This PR adds the `action_schedule` to the template for the created ResourceProvider.

The ResourceClaim’s resource templates are updated with defaults as defined by the ResourceProvider.

Each resource template in the ResourceClaim is checked for validity against the OpenAPIv3 schema in the ResourceProvider.