### PR TITLE
Updated to align with new date format written by LodeStar

### DIFF
--- a/inventory-generation/notifications/main.yaml
+++ b/inventory-generation/notifications/main.yaml
@@ -2,7 +2,7 @@
 - name: Generate email notifications to be consumed by Ansible Tower scheduled jobs
   hosts: notification_host
   gather_facts: false
-  
+
   tasks:
     - name: "Fail if directory and email_templates_directory are not provided"
       fail:
@@ -48,19 +48,19 @@
             src: "hosts"
             dest: "{{ directory }}/iac/inventories/notifications/inventory/hosts"
 
-      when: 
+      when:
         - notifications_dir.stat.exists is false
         - start_date is defined
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
         - (hosting_environments is defined) and (hosting_environments | length > 0)
-        - (archive_date | default('2006-01-02T15:04:05.000Z') | to_datetime('%Y-%m-%dT%H:%M:%S.%fZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
 
     - name: "Process list of users from template"
       template:
         src: list-of-users.yaml.j2
         dest: "{{ directory }}/iac/inventories/notifications/inventory/group_vars/all/list_of_users.yaml"
-      when: 
+      when:
         - start_date is defined
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
         - (hosting_environments is defined) and (hosting_environments | length > 0)
-        - (archive_date | default('2006-01-02T15:04:05.000Z') | to_datetime('%Y-%m-%dT%H:%M:%S.%fZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')

--- a/inventory-generation/tower_jobs_launch/main.yaml
+++ b/inventory-generation/tower_jobs_launch/main.yaml
@@ -85,6 +85,6 @@
         - start_date is defined
         - (hosting_environments is defined) and (hosting_environments | length > 0)
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
-        - (archive_date | default('2006-01-02T15:04:05.000Z') | to_datetime('%Y-%m-%dT%H:%M:%S.%fZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
 
 - import_playbook: '{{ infra_ansible_directory }}/playbooks/ansible/tower/configure-ansible-tower.yml'

--- a/inventory-generation/tower_jobs_schedules/main.yaml
+++ b/inventory-generation/tower_jobs_schedules/main.yaml
@@ -28,10 +28,10 @@
           copy:
             src: "hosts"
             dest: "{{ directory }}/iac/inventories/tower_jobs_schedules/inventory/hosts"
-      when: 
+      when:
         - start_date is defined
         - engagement_type | default('') == 'Residency'
-        - (archive_date | default('2006-01-02T15:04:05.000Z') | to_datetime('%Y-%m-%dT%H:%M:%S.%fZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
 
     - name: DO500 Engagement Type inventory
       block:
@@ -44,7 +44,7 @@
           copy:
             src: "hosts"
             dest: "{{ directory }}/iac/inventories/tower_jobs_schedules/inventory/hosts"
-      when: 
+      when:
         - start_date is defined
         - engagement_type | default('') == 'DO500'
-        - (archive_date | default('2006-01-02T15:04:05.000Z') | to_datetime('%Y-%m-%dT%H:%M:%S.%fZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -15,8 +15,8 @@ spec:
       spec:
         vars:
           action_schedule:
-            start: "{{ timestamp.utcnow }}"
-            stop: "{{ timestamp.utcnow.add('4h') }}"
+            start: "{{ now(utc=True).isoformat() }}"
+            stop: "{{ now(utc=True).isoformat() | add_time(hours=4) }}"
           {%- if desired_state is defined and desired_state|length %}
           desired_state: {{ desired_state }}
           {%- endif %}


### PR DESCRIPTION
This PR updates the datetime to use ISO format in two areas;

1. ResourceProvider template

The expected output should result in the following object being placed in the ResourceProvider;

```yaml
        vars:
          action_schedule:
            default_runtime: 4h
            maximum_runtime: 8h
            start: "2021-11-22T20:50:40Z"
            stop: "2021-11-23T00:50:40Z"
```

2. The fields read from `engagement.json` as per this [internal issue](https://gitlab.consulting.redhat.com/rht-labs/labs-sre/documentation/-/issues/919)
