### PR TITLE
Action Schedule

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -14,6 +14,7 @@ spec:
     template:
       spec:
         vars:
+          action_schedule: {}
           {%- if desired_state is defined and desired_state|length %}
           desired_state: {{ desired_state }}
           {%- endif %}

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -15,6 +15,9 @@ spec:
       spec:
         vars:
           # The action schedule is hardcoded to fixed dates to avoid any accidental shutdown.
+          # - these values are required by Babylon, but aren't in play for our use, 
+          #   and hence can be hardcoded to past/future values that are considered "safe" 
+          #   as we don't expect to hit these future dates in the lifespan of this solution
           action_schedule:
             default_runtime: 1000d
             maximum_runtime: 1000d

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -14,7 +14,12 @@ spec:
     template:
       spec:
         vars:
-          action_schedule: {}
+          # The action schedule is hardcoded to fixed dates to avoid any accidental shutdown.
+          action_schedule:
+            default_runtime: 1000d
+            maximum_runtime: 1000d
+            start: "2020-01-01T00:00:00Z"
+            stop: "2100-01-01T00:00:00Z"
           {%- if desired_state is defined and desired_state|length %}
           desired_state: {{ desired_state }}
           {%- endif %}


### PR DESCRIPTION
# Overview

Adds a workaround for missing `action_schedule` in an applied `ResourceClaim` by hardcoding the values to defined dates.

# Background

When applying the `ResourceClaim` template to the cluster for the first-time, Poolboy will add the `action_schedule` object with fields as required, the defaults are populated from the `ResourceProvider`.

ArgoCD is configured to ignore any changes to this object using `ignoreDifferences` from [PR #392](https://github.com/rht-labs/lodestar-deployment/pull/392)

On any subsequent update to the `ResourceClaim`, such as adding a new user or putting a user into the reset queue, ArgoCD will re-apply the template and Poolboy will report the following error when attempting to merge the `ResourceClaim` with the template defaults within the `ResourceProvider` due to the missing `action_schedule` field now being stripped.

```bash
'dict object' has no attribute 'action_schedule'",
```

By hardcoding the `action_schedule` values in the `ResourceClaim` template directly, the error is avoided with the added benefit of avoiding any accidental start/stop operations by using a long time period.