### PR TITLE
Add missing ocp_subdomain

### DIFF
--- a/inventory-generation/notifications/main.yaml
+++ b/inventory-generation/notifications/main.yaml
@@ -48,6 +48,8 @@
             src: "hosts"
             dest: "{{ directory }}/iac/inventories/notifications/inventory/hosts"
 
+      vars:
+        ocp_subdomain: "{{ hosting_environments[0].ocp_sub_domain | lower }}"
       when:
         - notifications_dir.stat.exists is false
         - start_date is defined

--- a/inventory-generation/notifications/main.yaml
+++ b/inventory-generation/notifications/main.yaml
@@ -56,6 +56,7 @@
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
         - (hosting_environments is defined) and (hosting_environments | length > 0)
         - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - hosting_environments[0].ocp_sub_domain is defined
 
     - name: "Process list of users from template"
       template:


### PR DESCRIPTION
This PR makes the `ocp_subdomain` variable availabe within the email templates that are configured to use it.

The variable is defined using the `hosting_environments[0].ocp_sub_domain` from the `engagement.json` file that has been read in previously within the same playbook.

This is shown by the following error from Resource Dispatcher logs;

```bash
TASK [Copy email template directory to DO500 Engagement repo and process as jinja2] ***
lodestar-argo-cd/resource-dispatcher-5-q64m4[resource-dispatcher]: failed: [localhost] (item=/tmp/tmpylg35ivc/email-template-repo/hosting/do500/en_us/onboard.yml.j2) => {"ansible_loop_var": "item", "changed": false, "item": "/tmp/tmpylg35ivc/email-template-repo/hosting/do500/en_us/onboard.yml.j2", "msg": "AnsibleUndefinedVariable: 'ocp_subdomain' is undefined"}
```