### PR TITLE
Remove ipa_host variable from manage-participants

### DIFF
--- a/inventory-generation/identity-management/main.yml
+++ b/inventory-generation/identity-management/main.yml
@@ -84,7 +84,6 @@
         - name: "Set Identity Provider facts"
           set_fact:
             idp_type: "{{ idp_type | default('idm') }}"
-            ipa_host: "{{ idp_host_url if idp_host_url is defined else 'ipa.apps.' + (hosting_environments[0].ocp_sub_domain | lower) + '.' + engagement_region | default('dev') + '-1.' + ocp_base_url }}"
             ipa_admin_user: "{{ ocp_admin_username }}"
             ipa_admin_password: "{{ ocp_admin_password }}"
             ipa_validate_certs: "{{ ipa_validate_certs | default(true) }}"
@@ -99,7 +98,6 @@
               project_name: "{{ project_name }}"
               ocp_subdomain: "{{ hosting_environments[0].ocp_sub_domain | lower }}"
               ipa_validate_certs: "{{ ipa_validate_certs }}"
-              ipa_host: "{{ ipa_host }}"
               ipa_admin_user: "{{ ipa_admin_user }}"
               ipa_admin_password: "{{ ipa_admin_password }}"
               list_of_mail_cc: "{{ cc_list }}"

--- a/manage-participants/main.yml
+++ b/manage-participants/main.yml
@@ -3,11 +3,14 @@
 - hosts: identity-hosts
   name: Verify Identity Provider
   tasks:
+    - name: "Fail if ocp_subdomain or subdomain_base_suffix not provided"
+      fail:
+        msg: "ocp_subdomain and subdomain_base_suffix vars needs to be provided in order to continue withe the playbook"
+      when:
+        - ocp_subdomain is undefined or subdomain_base_suffix is undefined
+
     - set_fact:
         ipa_host: "ipa.apps.{{ ocp_subdomain }}.{{ subdomain_base_suffix }}"
-      when:
-        - ocp_subdomain is defined
-        - subdomain_base_suffix is defined
 
     - name: Wait for IdM to be responsive
       uri:
@@ -17,8 +20,6 @@
       until: rc.status|trim|int == 200
       retries: 90
       delay: 60
-      when:
-        - ipa_host is defined
 
 - name: Remove participants from IdM
   import_playbook: "process_remove.yml"

--- a/manage-participants/main.yml
+++ b/manage-participants/main.yml
@@ -7,7 +7,8 @@
       fail:
         msg: "Variable ocp_subdomain ({{ ocp_subdomain | default('')}}) or subdomain_base_suffix ({{ subdomain_base_suffix | default('') }}) is not defined or empty"
       when:
-        - (ocp_subdomain is undefined or (ocp_subdomain | trim) == "") or (subdomain_base_suffix is undefined or (subdomain_base_suffix | trim) == "")
+        - (ocp_subdomain is undefined or ocp_subdomain|trim == "") or 
+          (subdomain_base_suffix is undefined or subdomain_base_suffix|trim == "")
 
     - set_fact:
         ipa_host: "ipa.apps.{{ ocp_subdomain }}.{{ subdomain_base_suffix }}"

--- a/manage-participants/main.yml
+++ b/manage-participants/main.yml
@@ -5,9 +5,9 @@
   tasks:
     - name: "Fail if ocp_subdomain or subdomain_base_suffix not provided"
       fail:
-        msg: "ocp_subdomain and subdomain_base_suffix vars needs to be provided in order to continue withe the playbook"
+        msg: "Variable ocp_subdomain ({{ ocp_subdomain | default('')}}) or subdomain_base_suffix ({{ subdomain_base_suffix | default('') }}) is not defined or empty"
       when:
-        - ocp_subdomain is undefined or subdomain_base_suffix is undefined
+        - (ocp_subdomain is undefined or (ocp_subdomain | trim) == "") or (subdomain_base_suffix is undefined or (subdomain_base_suffix | trim) == "")
 
     - set_fact:
         ipa_host: "ipa.apps.{{ ocp_subdomain }}.{{ subdomain_base_suffix }}"

--- a/manage-participants/main.yml
+++ b/manage-participants/main.yml
@@ -3,6 +3,11 @@
 - hosts: identity-hosts
   name: Verify Identity Provider
   tasks:
+    - set_fact:
+        ipa_host: "ipa.apps.{{ ocp_subdomain }}.{{ subdomain_base_suffix }}"
+      when:
+        - ocp_subdomain is defined
+        - subdomain_base_suffix is defined
 
     - name: Wait for IdM to be responsive
       uri:


### PR DESCRIPTION
The ipa_host variable should be set at main entry point based on
ocp_subdomain and subdomain_base_suffix variables provided externally.