### PR TITLE
Making timestamp processing consistent to avoid timestamp format issues

### DIFF
--- a/inventory-generation/notifications/main.yaml
+++ b/inventory-generation/notifications/main.yaml
@@ -20,6 +20,11 @@
         path: "{{ directory }}/iac/inventories/notifications/inventory/group_vars/all"
       register: notifications_dir
 
+    - name: "Pre-process timestamps"
+      set_fact:
+        - archive_date_in_seconds: "{{ (archive_date | default('2000-01-01T') | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%s') }}" 
+        - time_now_in_seconds: "{{ now(utc=true, fmt='%s') }}"
+
     - name: "Copy email templates from main repo to engagement repo - if the target directory does NOT already exist"
       block:
         - name: "Add directory for group_vars/all"
@@ -56,7 +61,7 @@
         - start_date is defined
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
         - (hosting_environments is defined) and (hosting_environments | length > 0)
-        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - archive_date_in_seconds > time_now_in_seconds
         - hosting_environments[0].ocp_sub_domain is defined
         - ocp_base_url is defined
 
@@ -68,4 +73,4 @@
         - start_date is defined
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
         - (hosting_environments is defined) and (hosting_environments | length > 0)
-        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - archive_date_in_seconds > time_now_in_seconds

--- a/inventory-generation/tower_jobs_launch/main.yaml
+++ b/inventory-generation/tower_jobs_launch/main.yaml
@@ -7,15 +7,20 @@
       when:
         - directory is undefined or (directory | trim) == ""
 
-    - name: Read Engagement Data
+    - name: 'Read Engagement Data'
       include_vars:
         file: '{{ directory }}/engagement.json'
 
-    - name: Set customer engagement
+    - name: 'Set customer engagement'
       set_fact:
         customer_engagement: "{{ customer_name | lower | replace(' ', '_') }}-{{ project_name | lower | replace(' ', '_') }}"
 
-    - name: Set facts to bootstrap scheduled notifications into Ansible Tower
+    - name: 'Pre-process timestamps'
+      set_fact:
+        - archive_date_in_seconds: "{{ (archive_date | default('2000-01-01T') | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%s') }}"
+        - time_now_in_seconds: "{{ now(utc=true, fmt='%s') }}"
+
+    - name: 'Set facts to bootstrap scheduled notifications into Ansible Tower'
       set_fact:
         delete_missing_items: false
         ansible_tower:
@@ -85,6 +90,6 @@
         - start_date is defined
         - (hosting_environments is defined) and (hosting_environments | length > 0)
         - engagement_type | default('') == 'Residency' or engagement_type | default('') == 'DO500'
-        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - archive_date_in_seconds > time_now_in_seconds
 
 - import_playbook: '{{ infra_ansible_directory }}/playbooks/ansible/tower/configure-ansible-tower.yml'

--- a/inventory-generation/tower_jobs_schedules/main.yaml
+++ b/inventory-generation/tower_jobs_schedules/main.yaml
@@ -9,16 +9,21 @@
       when:
         - directory is undefined or (directory | trim) == ""
 
-    - name: Read Engagement Data
+    - name: 'Read Engagement Data'
       include_vars:
         file: "{{ directory }}/engagement.json"
 
-    - name: Combine customer and engagement name
+    - name: 'Combine customer and engagement name'
       set_fact:
         customer_engagement: "{{ customer_name | lower | replace(' ', '_') }}-{{ project_name | lower | replace(' ', '_') }}"
 
-    - name: Residency Engagement Type inventory
-      block:
+    - name: 'Pre-process timestamps'
+      set_fact:
+        - archive_date_in_seconds: "{{ (archive_date | default('2000-01-01T') | regex_replace('^(.*)T.*$', '\\1') | to_datetime('%Y-%m-%d')).strftime('%s') }}"
+        - time_now_in_seconds: "{{ now(utc=true, fmt='%s') }}"
+
+    - name: 'Residency Engagement Type inventory'
+      block:`
         - name: "Write inventory to file"
           template:
             src: "residency-tower-management-host.yaml.j2"
@@ -31,9 +36,9 @@
       when:
         - start_date is defined
         - engagement_type | default('') == 'Residency'
-        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - archive_date_in_seconds > time_now_in_seconds
 
-    - name: DO500 Engagement Type inventory
+    - name: 'DO500 Engagement Type inventory'
       block:
         - name: "Write inventory to file"
           template:
@@ -47,4 +52,4 @@
       when:
         - start_date is defined
         - engagement_type | default('') == 'DO500'
-        - (archive_date | default('2006-01-02T15:04:05Z') | to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') > now(utc=true).strftime('%s')
+        - archive_date_in_seconds > time_now_in_seconds


### PR DESCRIPTION
The processing of timestamps have been causing pain due to inconsistency. This PR aligns all timestamp processing to use the same method to filter out the date from a ISO compliant timestamp and convert it to seconds (epoch). 