### PR TITLE
Setting notifications to 'False' for LDAP user

### DIFF
--- a/inventory-generation/identity-management/main.yml
+++ b/inventory-generation/identity-management/main.yml
@@ -37,7 +37,7 @@
 
     - name: "Add LDAP Service Account"
       set_fact:
-        users: "{{ (users | default([])) + [ { 'first_name': 'LDAP', 'last_name': 'SA', 'email': 'ldap@localhost.com', 'user_name': ocp_ldap_sa_username, 'generate_password': false, 'password': ocp_ldap_sa_password  } ] }}"
+        users: "{{ (users | default([])) + [ { 'first_name': 'LDAP', 'last_name': 'SA', 'email': 'ldap@localhost.com', 'user_name': ocp_ldap_sa_username, 'generate_password': False, 'notify_user': False, 'password': ocp_ldap_sa_password  } ] }}"
 
     - name: "Get Unique Groups"
       set_fact:


### PR DESCRIPTION
Setting flag to ensure the ldap user notification doesn't get sent out to the point of contacts, etc. 