### PR TITLE
Fixing the subdomain_base_suffix variable

### DIFF
--- a/inventory-generation/notifications/main.yaml
+++ b/inventory-generation/notifications/main.yaml
@@ -55,7 +55,7 @@
 
       vars:
         ocp_subdomain: "{{ hosting_environments[0].ocp_sub_domain | lower }}"
-        subdomain_base_suffix: "{{ engagement_region | default('dev') + cloud_provider_index | default('-1') + ocp_base_url }}"
+        subdomain_base_suffix: "{{ engagement_region | default('dev') + cloud_provider_index | default('-1') + '.' + ocp_base_url }}"
       when:
         - notifications_dir.stat.exists is false
         - start_date is defined


### PR DESCRIPTION
The subdomain_base_suffix missing '.' dot between engagement_region and
ocp_base_url