### PR TITLE
Fix email to IdM username translation

### DIFF
--- a/inventory-generation/identity-management/process_user_entry.yml
+++ b/inventory-generation/identity-management/process_user_entry.yml
@@ -2,6 +2,7 @@
 
 - set_fact:
     name_append: ''
+    username_regex: '[\!$&*-=^\`|~#%+/?{}]'
 
 - set_fact:
     prefix: "{{ item.username_alteration.prefix | d('') }}"
@@ -20,7 +21,7 @@
       first_name: "{{ user_item.first_name|trim }}"
       last_name: "{{ user_item.last_name|trim }}{{ name_append|d('') }}"
       email: "{{ user_item.email|trim }}"
-      user_name: "{{ prefix }}{{ user_item.email.split('@')[0]|trim }}{{ suffix }}"
+      user_name: "{{ prefix }}{{ user_item.email.split('@')[0]|trim|regex_replace(username_regex, '_') }}{{ suffix }}"
       state: "{{ user_item.state | d('present') }}"
 
 - set_fact:


### PR DESCRIPTION
According to [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822#section-3.2.4), the local part of an email address (before the `@` is allowed the following non alpha numeric characters
```
atext           =       ALPHA / DIGIT / ; Any character except controls,
                        "!" / "#" /     ;  SP, and specials.
                        "$" / "%" /     ;  Used for atoms
                        "&" / "'" /
                        "*" / "+" /
                        "-" / "/" /
                        "=" / "?" /
                        "^" / "_" /
                        "`" / "{" /
                        "|" / "}" /
                        "~"
```

This PR will translate any of these characters into an underscore:
```
ansible -i inventory localhost -m debug -a "msg={{ email.split('@')[0]|trim|regex_replace(regex, '_')}}" -e email='pabraham|test@redhat.com' -e regex='[\!$&*-=^\`|~#%+/?{}]'
localhost | SUCCESS => {
    "msg": "pabraham_test"
}
```
:warning: The `'` character has been left out of the characters being replaced. Help with escaping is appreciated.