### PR TITLE
Adding labels to resourceclaim

### DIFF
--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -4,6 +4,9 @@ apiVersion: poolboy.gpte.redhat.com/v1
 kind: ResourceClaim
 metadata:
   name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}-{{ project_id }}
+  labels:
+    "babylon.gpte.redhat.com/catalogItemName": do500.ocp4.dev
+    "babylon.gpte.redhat.com/catalogItemNamespace": openshift
 spec:
   resources:
   - provider:

--- a/templates/resourceclaim.yaml.j2
+++ b/templates/resourceclaim.yaml.j2
@@ -5,7 +5,7 @@ kind: ResourceClaim
 metadata:
   name: {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}-{{ project_id }}
   labels:
-    "babylon.gpte.redhat.com/catalogItemName": do500.ocp4.dev
+    "babylon.gpte.redhat.com/catalogItemName": {{ (engagement_type | lower) + '.' + (governor_type | lower) + '.' + (governor_spec | lower ) }}
     "babylon.gpte.redhat.com/catalogItemNamespace": openshift
 spec:
   resources:


### PR DESCRIPTION
The following labels needs to be set at resourceclaim's metadata:
- babylon.gpte.redhat.com/catalogItemName
- babylon.gpte.redhat.com/catalogItemNamespace

These labels used by the babylon-notifier to filter events and retrieve information needed to prepare notification text.
